### PR TITLE
bugfix: align DeFiLlama metrics with UTC day

### DIFF
--- a/src/jobs/network_tvl.sql
+++ b/src/jobs/network_tvl.sql
@@ -15,9 +15,11 @@ as $$
   ),
   transformed as (
     select
+      -- DeFiLlama timestamps are midnight UTC; forward range ensures row
+      -- is labeled with the same calendar day
       int8range(
-        (to_timestamp(date_sec) - '1 day'::interval)::timestamp9::bigint,
-        (to_timestamp(date_sec))::timestamp9::bigint
+        (to_timestamp(date_sec))::timestamp9::bigint,
+        (to_timestamp(date_sec) + '1 day'::interval)::timestamp9::bigint
       ) as timestamp_range,
     tvl
     from defillama

--- a/src/jobs/stablecoin_marketcap.sql
+++ b/src/jobs/stablecoin_marketcap.sql
@@ -15,9 +15,11 @@ as $$
   ),
   transformed as (
     select
+      -- DeFiLlama timestamps are midnight UTC; forward range ensures row
+      -- is labeled with the same calendar day
       int8range(
-        (to_timestamp(date_sec) - '1 day'::interval)::timestamp9::bigint,
-        (to_timestamp(date_sec))::timestamp9::bigint
+        (to_timestamp(date_sec))::timestamp9::bigint,
+        (to_timestamp(date_sec) + '1 day'::interval)::timestamp9::bigint
       ) as timestamp_range,
     marketcap
     from defillama


### PR DESCRIPTION
## Summary
- correct timestamp window for network TVL loader
- correct timestamp window for stablecoin market cap loader

This change ensures each metric row is written to the bucket for the same calendar day that DeFiLlama reports. DeFiLlama dates are midnight UTC, so the loaders now build a forward-looking one-day `int8range` from the start of that day.

## Testing
- `git status --short`
