### PR TITLE
Increase DeFi Llama ingestion frequency

### DIFF
--- a/src/dashboard/Hgraph - Hedera Stats (Beta)-1744592698695.json
+++ b/src/dashboard/Hgraph - Hedera Stats (Beta)-1744592698695.json
@@ -13388,7 +13388,7 @@
             "type": "yesoreyeram-infinity-datasource",
             "uid": "${DS_HGRAPH}"
           },
-          "description": "The most recent Stablecoin Marketcap for Hedera (updated daily).",
+          "description": "The most recent Stablecoin Marketcap for Hedera (updated every 10 minutes).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -15105,7 +15105,7 @@
             "type": "yesoreyeram-infinity-datasource",
             "uid": "${DS_HGRAPH}"
           },
-          "description": "The most recent Stablecoin Marketcap for Hedera (updated daily).",
+          "description": "The most recent Stablecoin Marketcap for Hedera (updated every 10 minutes).",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/src/jobs/pg_cron.sql
+++ b/src/jobs/pg_cron.sql
@@ -87,8 +87,8 @@ select cron.schedule_in_database(
 
 select cron.schedule_in_database(
     'call ecosystem.load_network_tvl()',
-    -- daily after midnight UTC
-    '2 0 * * *',
+    -- every 10 minutes starting at minute 2
+    '2-59/10 * * * *',
     'call ecosystem.load_network_tvl();',
     '<database_name>',
     '<database_user>'
@@ -96,8 +96,8 @@ select cron.schedule_in_database(
 
 select cron.schedule_in_database(
     'call ecosystem.load_stablecoin_marketcap()',
-    -- daily after midnight UTC
-    '3 0 * * *',
+    -- every 10 minutes starting at minute 3
+    '3-59/10 * * * *',
     'call ecosystem.load_stablecoin_marketcap()',
     '<database_name>',
     '<database_user>'


### PR DESCRIPTION
## Summary
- bump DeFi Llama metrics schedules from daily to every 10 min
- note frequent refresh in dashboard description

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_683e201ae55883228ee8f4e486570484