### PR TITLE
Adding "Total" Account/Contract statistics

### DIFF
--- a/src/jobs/load_daily_metrics.sql
+++ b/src/jobs/load_daily_metrics.sql
@@ -8,7 +8,11 @@ declare
     metrics text[] := array [
       'network_fee',
       'network_tps',
-      'new_accounts'
+      'new_accounts',
+      'total_accounts',
+      'total_ecdsa_accounts',
+      'total_ed25519_accounts',
+      'total_smart_contracts'
     ];
     metric_name text;
 

--- a/src/metric_descriptions.sql
+++ b/src/metric_descriptions.sql
@@ -25,7 +25,11 @@ values
     ('network_tvl', 'Total value locked (USD) in the ecosystem during the period', ''),
     ('stablecoin_marketcap', 'Total market capitalization (USD) of stablecoins in the ecosystem during the period', ''),
     ('avg_usd_conversion', 'Average conversion of HBAR to US dollars multiplied by 10,000 during the period', 'The average of candlestick closing prices for a given period for the HBAR/USDT pair on the five major exchanges by trading volume (Binance, Bybit, OKX, Bitget and MEXC) was calculated. The price is multiplied by 10,000 for integer representation for each time period.'),
-    ('new_accounts', 'New accounts created on the Hedera network per period', '')
+    ('new_accounts', 'New accounts created on the Hedera network per period', ''),
+    ('total_accounts', 'Total (cumulative) accounts created on the Hedera network per period', ''),
+    ('total_ecdsa_accounts', 'Total (cumulative) accounts with ECDSA keys created on the Hedera network per period', ''),
+    ('total_ed25519_accounts', 'Total (cumulative) accounts with Ed25519 keys created on the Hedera network per period', ''),
+    ('total_smart_contracts', 'Total (cumulative) smart contracts created on the Hedera network per period', '')
 on conflict (name) do update
 set
     description = excluded.description,

--- a/src/metrics/total_accounts.sql
+++ b/src/metrics/total_accounts.sql
@@ -1,0 +1,37 @@
+create or replace function ecosystem.total_accounts(
+  period text,
+  start_timestamp bigint default 0,
+  end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
+)
+returns setof ecosystem . metric_total
+language sql stable
+as $$
+
+with all_entries as (
+  select created_timestamp
+  from entity
+  where type = 'ACCOUNT'
+    and created_timestamp between start_timestamp and end_timestamp
+),
+accounts_per_period as (
+  select
+    date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
+    count(*) as accounts_created
+  from all_entries
+  group by 1
+),
+total_accounts as (
+  select
+    period_start_timestamp,
+    sum(accounts_created) over (order by period_start_timestamp) as total
+  from accounts_per_period
+)
+select
+  int8range(
+    period_start_timestamp::timestamp9::bigint,
+    (lead(period_start_timestamp) over (order by period_start_timestamp rows between current row and 1 following))::timestamp9::bigint
+  ) as timestamp_range,
+  total
+from total_accounts
+
+$$;

--- a/src/metrics/total_ecdsa_accounts.sql
+++ b/src/metrics/total_ecdsa_accounts.sql
@@ -1,0 +1,40 @@
+create or replace function ecosystem.total_ecdsa_accounts(
+  period text,
+  start_timestamp bigint default 0,
+  end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
+)
+returns setof ecosystem . metric_total
+language sql stable
+as $$
+
+  with all_entries as (
+    select distinct e.id, e.created_timestamp
+    from entity e
+    join transaction t on t.payer_account_id = e.id
+    where e.type = 'ACCOUNT'
+      and encode(substring(e.key from 1 for 1), 'hex') = '12'
+      and t.result = 22
+      and e.created_timestamp between start_timestamp and end_timestamp
+  ),
+accounts_per_period as (
+  select
+    date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
+    count(*) as accounts_created
+  from all_entries
+  group by 1
+),
+total_accounts as (
+  select
+    period_start_timestamp,
+    sum(accounts_created) over (order by period_start_timestamp) as total
+  from accounts_per_period
+)
+select
+  int8range(
+    period_start_timestamp::timestamp9::bigint,
+    (lead(period_start_timestamp) over (order by period_start_timestamp rows between current row and 1 following))::timestamp9::bigint
+  ) as timestamp_range,
+  total
+from total_accounts
+
+$$;

--- a/src/metrics/total_ed25519_accounts.sql
+++ b/src/metrics/total_ed25519_accounts.sql
@@ -1,0 +1,40 @@
+create or replace function ecosystem.total_ed25519_accounts(
+  period text,
+  start_timestamp bigint default 0,
+  end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
+)
+returns setof ecosystem . metric_total
+language sql stable
+as $$
+
+  with all_entries as (
+    select distinct e.id, e.created_timestamp
+    from entity e
+    join transaction t on t.payer_account_id = e.id
+    where e.type = 'ACCOUNT'
+      and encode(substring(e.key from 3 for 1), 'hex') in ('02', '03')
+      and t.result = 22
+      and e.created_timestamp between start_timestamp and end_timestamp
+  ),
+accounts_per_period as (
+  select
+    date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
+    count(*) as accounts_created
+  from all_entries
+  group by 1
+),
+total_accounts as (
+  select
+    period_start_timestamp,
+    sum(accounts_created) over (order by period_start_timestamp) as total
+  from accounts_per_period
+)
+select
+  int8range(
+    period_start_timestamp::timestamp9::bigint,
+    (lead(period_start_timestamp) over (order by period_start_timestamp rows between current row and 1 following))::timestamp9::bigint
+  ) as timestamp_range,
+  total
+from total_accounts
+
+$$;

--- a/src/metrics/total_smart_contracts.sql
+++ b/src/metrics/total_smart_contracts.sql
@@ -1,0 +1,37 @@
+create or replace function ecosystem.total_smart_contracts(
+  period text,
+  start_timestamp bigint default 0,
+  end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
+)
+returns setof ecosystem . metric_total
+language sql stable
+as $$
+
+with all_entries as (
+  select created_timestamp
+  from entity
+  where type = 'CONTRACTS'
+  and created_timestamp between start_timestamp and end_timestamp
+),
+contracts_per_period as (
+  select
+    date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
+    count(*) as contracts_created
+  from all_entries
+  group by 1
+),
+total_contracts as (
+  select
+    period_start_timestamp,
+    sum(contracts_created) over (order by period_start_timestamp) as total
+  from contracts_per_period
+)
+select
+  int8range(
+    period_start_timestamp::timestamp9::bigint,
+    (lead(period_start_timestamp) over (order by period_start_timestamp rows between current row and 1 following))::timestamp9::bigint
+  ) as timestamp_range,
+  total
+from total_contracts
+
+$$;


### PR DESCRIPTION
This PR adds the functions, jobs and metadata for:

- `total_accounts`
- `total_ecdsa_accounts`
- `total_ed25519_accounts`
- `total_smart_contracts`

Logic was tested with different queries in the docs (I only have read-only access).