### PR TITLE
Add new "Active" Ed/EC accounts metric.

### DIFF
--- a/src/jobs/load_hourly_metrics.sql
+++ b/src/jobs/load_hourly_metrics.sql
@@ -21,6 +21,8 @@ declare
         'active_retail_accounts',
         'active_smart_contracts',
         'active_accounts',
+        'active_ecdsa_accounts',
+        'active_ed25519_accounts',
         'network_fee',
         'account_growth',
         'network_tps',

--- a/src/jobs/load_metrics.sql
+++ b/src/jobs/load_metrics.sql
@@ -11,6 +11,8 @@ declare
         'active_developer_accounts',
         'active_retail_accounts',
         'active_smart_contracts',
+        'active_ecdsa_accounts',
+        'active_ed25519_accounts',
         'accounts_associating_nfts',
         'accounts_receiving_nfts',
         'accounts_sending_nfts',

--- a/src/metric_descriptions.sql
+++ b/src/metric_descriptions.sql
@@ -25,7 +25,9 @@ values
     ('network_tvl', 'Total value locked (USD) in the ecosystem during the period', ''),
     ('stablecoin_marketcap', 'Total market capitalization (USD) of stablecoins in the ecosystem during the period', ''),
     ('avg_usd_conversion', 'Average conversion of HBAR to US dollars multiplied by 10,000 during the period', 'The average of candlestick closing prices for a given period for the HBAR/USDT pair on the five major exchanges by trading volume (Binance, Bybit, OKX, Bitget and MEXC) was calculated. The price is multiplied by 10,000 for integer representation for each time period.'),
-    ('new_accounts', 'New accounts created on the Hedera network per period', '')
+    ('new_accounts', 'New accounts created on the Hedera network per period', ''),
+    ('active_ecdsa_accounts', 'The number equal developers + retails during the period filtered by ECDSA account key type.', ''),
+    ('active_ed25519_accounts', 'The number equal developers + retails during the period filtered by Ed25519 account key type.', ''),
 on conflict (name) do update
 set
     description = excluded.description,

--- a/src/metrics/active_ecdsa_accounts.sql
+++ b/src/metrics/active_ecdsa_accounts.sql
@@ -1,0 +1,35 @@
+create or replace function ecosystem.active_ecdsa_accounts(
+    period text,
+    start_timestamp bigint default 0,
+    end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
+)
+returns setof ecosystem . metric_total
+as $$
+with raw_active_accounts as (
+  select * from ecosystem.active_developer_accounts(period, start_timestamp, end_timestamp)
+  union all
+  select * from ecosystem.active_retail_accounts(period, start_timestamp, end_timestamp)
+),
+active_ecdsa_accounts as (
+  select d.*
+  from raw_active_accounts d
+  join public.entity e
+    on d.account_id = e.id
+   and encode(substring(e.key from 1 for 1), 'hex') = '12' 
+),
+merged_data as (
+  select
+    lower(int8range) as period_start_timestamp,
+    sum(total) as total
+  from active_ecdsa_accounts
+  group by 1
+  order by 1 desc
+)
+select
+  int8range(
+    period_start_timestamp::timestamp9::bigint,
+    coalesce((lead(period_start_timestamp) over (order by period_start_timestamp rows between current row and 1 following))::timestamp9::bigint, end_timestamp)
+  ),
+  total
+from merged_data
+$$ language sql stable;

--- a/src/metrics/active_ed25519_accounts.sql
+++ b/src/metrics/active_ed25519_accounts.sql
@@ -1,0 +1,35 @@
+create or replace function ecosystem.active_ed25519_accounts(
+    period text,
+    start_timestamp bigint default 0,
+    end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
+)
+returns setof ecosystem . metric_total
+as $$
+with raw_active_accounts as (
+  select * from ecosystem.active_developer_accounts(period, start_timestamp, end_timestamp)
+  union all
+  select * from ecosystem.active_retail_accounts(period, start_timestamp, end_timestamp)
+),
+active_ed25519_accounts as (
+  select d.*
+  from raw_active_accounts d
+  join public.entity e
+    on d.account_id = e.id
+   and encode(substring(e.key from 3 for 1), 'hex') in ('02', '03')
+),
+merged_data as (
+  select
+    lower(int8range) as period_start_timestamp,
+    sum(total) as total
+  from active_ed25519_accounts
+  group by 1
+  order by 1 desc
+)
+select
+  int8range(
+    period_start_timestamp::timestamp9::bigint,
+    coalesce((lead(period_start_timestamp) over (order by period_start_timestamp rows between current row and 1 following))::timestamp9::bigint, end_timestamp)
+  ),
+  total
+from merged_data
+$$ language sql stable;


### PR DESCRIPTION
This PR adds the functions, jobs and metadata for:

- `active_ecdsa_accounts`
- `active_ed25519_accounts`

Was not able to properly test with read only access.