### PR TITLE
New accounts metric showing incorrect data

### DIFF
--- a/src/metrics/new_ecdsa_accounts.sql
+++ b/src/metrics/new_ecdsa_accounts.sql
@@ -1,37 +1,23 @@
-create or replace function ecosystem.new_ecdsa_accounts(
-  period text,
-  start_timestamp bigint default 0,
-  end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
-)
-returns setof ecosystem . metric_total
-language sql stable
-as $$
-
-  with all_entries as (
-    select distinct e.id, e.created_timestamp
-    from entity e
-    join transaction t on t.payer_account_id = e.id
-    where e.type = 'ACCOUNT'
-      and encode(substring(e.key from 1 for 1), 'hex') = '12'
-      and t.result = 22
-      and e.created_timestamp between start_timestamp and end_timestamp
-  ),
-  accounts_per_period as (
-    select
-      date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
-      count(*) as total
-    from all_entries
-    group by 1
-    order by 1 asc
-  )
-  select
-    int8range(
-      period_start_timestamp::timestamp9::bigint,
-      (
-        lead(period_start_timestamp)
-        over (order by period_start_timestamp rows between current row and 1 following)
-      )::timestamp9::bigint
-    ),
-    total
-  from accounts_per_period
-$$;
+CREATE
+OR
+replace FUNCTION ecosystem.new_ecdsa_accounts( period text, start_timestamp bigint DEFAULT 0, end_timestamp bigint DEFAULT CURRENT_TIMESTAMP::timestamp9::bigint )
+returns setof ecosystem.metric_total language sql stable AS $$ WITH all_entries AS
+(
+       SELECT e.id,
+              e.created_timestamp
+       FROM   entity e
+       WHERE  e.type = 'ACCOUNT'
+       AND    e.KEY IS NOT NULL
+       AND    e.created_timestamp IS NOT NULL
+       AND    (
+                     e.public_key LIKE '02%'
+              OR     e.public_key LIKE '03%')
+       AND    e.created_timestamp BETWEEN start_timestamp AND    end_timestamp ), accounts_per_period AS
+(
+         SELECT   date_trunc(period, to_timestamp(created_timestamp / 1e9)) AS period_start_timestamp,
+                  count(*)                                                  AS total
+         FROM     all_entries
+         GROUP BY 1
+         ORDER BY 1 ASC )SELECT   int8range( period_start_timestamp::timestamp9::bigint, ( lead(period_start_timestamp) OVER (ORDER BY period_start_timestamp rows BETWEEN CURRENT row AND      1 following) )::timestamp9::bigint ),
+         total
+FROM     accounts_per_period $$;

--- a/src/metrics/new_ed25519_accounts.sql
+++ b/src/metrics/new_ed25519_accounts.sql
@@ -1,37 +1,20 @@
-create or replace function ecosystem.new_ed25519_accounts(
-  period text,
-  start_timestamp bigint default 0,
-  end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
-)
-returns setof ecosystem . metric_total
-language sql stable
-as $$
-
-  with all_entries as (
-    select distinct e.id, e.created_timestamp
-    from entity e
-    join transaction t on t.payer_account_id = e.id
-    where e.type = 'ACCOUNT'
-      and encode(substring(e.key from 3 for 1), 'hex') in ('02', '03')
-      and t.result = 22
-      and e.created_timestamp between start_timestamp and end_timestamp
-  ),
-  accounts_per_period as (
-    select
-      date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
-      count(*) as total
-    from all_entries
-    group by 1
-    order by 1 asc
-  )
-  select
-    int8range(
-      period_start_timestamp::timestamp9::bigint,
-      (
-        lead(period_start_timestamp)
-        over (order by period_start_timestamp rows between current row and 1 following)
-      )::timestamp9::bigint
-    ),
-    total
-  from accounts_per_period
-$$;
+CREATE
+OR
+replace FUNCTION ecosystem.new_ed25519_accounts( period text, start_timestamp bigint DEFAULT 0, end_timestamp bigint DEFAULT CURRENT_TIMESTAMP::timestamp9::bigint )
+returns setof ecosystem.metric_total language sql stable AS $$ WITH all_entries AS
+(
+       SELECT e.id,
+              e.created_timestamp
+       FROM   entity e
+       WHERE  e.type = 'ACCOUNT'
+       AND    e.KEY IS NOT NULL
+       AND    substring(e.KEY FROM 1 FOR 2) = e'\\x1220'
+       AND    e.created_timestamp BETWEEN start_timestamp AND    end_timestamp ), accounts_per_period AS
+(
+         SELECT   date_trunc(period, to_timestamp(created_timestamp / 1e9)) AS period_start_timestamp,
+                  count(*)                                                  AS total
+         FROM     all_entries
+         GROUP BY 1
+         ORDER BY 1 ASC )SELECT   int8range( period_start_timestamp::timestamp9::bigint, ( lead(period_start_timestamp) OVER (ORDER BY period_start_timestamp rows BETWEEN CURRENT row AND      1 following) )::timestamp9::bigint ),
+         total
+FROM     accounts_per_period $$;

--- a/src/metrics/new_smart_contracts.sql
+++ b/src/metrics/new_smart_contracts.sql
@@ -1,32 +1,21 @@
-create or replace function ecosystem.new_smart_contracts(
-  period text,
-  start_timestamp bigint default 0,
-  end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
-)
-returns setof ecosystem . metric_total
-language sql stable
-as $$
-
-with all_entries as (
-  select created_timestamp
-  from entity
-  where type = 'CONTRACT'
-  and created_timestamp between start_timestamp and end_timestamp
-),
-contracts_per_period as (
-  select date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
-  count(*) as total
-  from all_entries
-  group by 1
-  order by 1 asc
-)
-select
-int8range(
-  period_start_timestamp::timestamp9::bigint,
-  (lead(period_start_timestamp) over (order by period_start_timestamp rows between current row and 1 following))::timestamp9::bigint
-),
-total
-
-from contracts_per_period
-
-$$;
+CREATE
+OR
+replace FUNCTION ecosystem.new_smart_contracts( period text, start_timestamp bigint DEFAULT 0, end_timestamp bigint DEFAULT CURRENT_TIMESTAMP::timestamp9::bigint )
+returns setof ecosystem.metric_total language sql stable AS $$ WITH all_entries AS
+(
+       SELECT e.created_timestamp
+       FROM   entity e
+       JOIN   TRANSACTION t
+       ON     e.created_timestamp = t.consensus_timestamp
+       WHERE  e.type = 'CONTRACT'
+       AND    t.type = 8    -- CONTRACTCREATEINSTANCE
+       AND    t.result = 22 -- SUCCESS
+       AND    e.created_timestamp BETWEEN start_timestamp AND    end_timestamp ), contracts_per_period AS
+(
+         SELECT   date_trunc(period, created_timestamp::timestamp9::timestamp) AS period_start_timestamp,
+                  count(*)                                                     AS total
+         FROM     all_entries
+         GROUP BY 1
+         ORDER BY 1 ASC )SELECT   int8range( period_start_timestamp::timestamp9::bigint, (lead(period_start_timestamp) OVER (ORDER BY period_start_timestamp rows BETWEEN CURRENT row AND      1 following))::timestamp9::bigint ),
+         total
+FROM     contracts_per_period $$;


### PR DESCRIPTION
this PR resolves an issue where `new_ecdsa_accounts`, `new_ed25519_accounts` and `new_smart_contracts` were showing incorrect data.

the issue identified: logic in the function was still enforcing "successful transaction creation" as a component, vs all entities regardless of engagement with the network.

modifies 3 files.