### PR TITLE
Issue: Incorrect calculation for `total_` metrics for new periods

### DIFF
--- a/src/jobs/load_init_metrics.sql
+++ b/src/jobs/load_init_metrics.sql
@@ -8,10 +8,7 @@ declare
 
     -- trimmed to the five requested metrics
     metrics text[] := array[
-        'total_accounts',
-        'total_ecdsa_accounts',
-        'total_ed25519_accounts',
-        'active_ed25519_accounts'
+        'total_smart_contracts'
     ];
     metric text;
 

--- a/src/metrics/total_accounts.sql
+++ b/src/metrics/total_accounts.sql
@@ -1,45 +1,46 @@
-create 
-or replace function ecosystem.total_accounts(
-  period text, start_timestamp bigint default 0, 
-  end_timestamp bigint default CURRENT_TIMESTAMP :: timestamp9 :: bigint
-) returns setof ecosystem.metric_total language sql stable as $$ with all_entries as (
-  select  distinct on (num)
-          created_timestamp 
-  from 
-    entity 
-  where 
-    type = 'ACCOUNT' 
-    and created_timestamp between start_timestamp 
-    and end_timestamp
-    order  by num, created_timestamp
-), 
+create or replace function ecosystem.total_accounts(
+  period text, 
+  start_timestamp bigint default 0, 
+  end_timestamp bigint default current_timestamp::timestamp9::bigint
+) returns setof ecosystem.metric_total
+language sql stable
+as $$
+with base_total as (
+  -- Count all accounts created before the start of this slice
+  select count(*)::bigint as base
+  from (
+    select distinct on (num) num
+    from entity
+    where type = 'ACCOUNT'
+      and created_timestamp < start_timestamp
+    order by num, created_timestamp
+  ) t
+),
+all_entries as (
+  select distinct on (num)
+    created_timestamp
+  from entity
+  where type = 'ACCOUNT'
+    and created_timestamp between start_timestamp and end_timestamp
+  order by num, created_timestamp
+),
 accounts_per_period as (
-  select 
-    date_trunc(
-      period, created_timestamp :: timestamp9 :: timestamp
-    ) as period_start_timestamp, 
-    count(*) as total_accounts 
-  from 
-    all_entries 
-  group by 
-    1 
-  order by 
-    1 asc
-) 
-select 
+  select
+    date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
+    count(*) as total_accounts
+  from all_entries
+  group by 1
+  order by 1 asc
+)
+select
   int8range(
-    period_start_timestamp :: timestamp9 :: bigint, 
-    (
-      lead(period_start_timestamp) over (
-        order by 
-          period_start_timestamp rows between current row 
-          and 1 following
-      )
-    ):: timestamp9 :: bigint
-  ), 
-  sum(total_accounts) over (
-    order by 
-      period_start_timestamp asc
-  ) as total 
-from 
-  accounts_per_period $$;
+    period_start_timestamp::timestamp9::bigint,
+    lead(period_start_timestamp) over (
+      order by period_start_timestamp
+    )::timestamp9::bigint
+  ) as timestamp_range,
+  (select base from base_total)
+    + sum(total_accounts) over (order by period_start_timestamp) as total
+from accounts_per_period
+order by period_start_timestamp;
+$$;

--- a/src/metrics/total_ecdsa_accounts.sql
+++ b/src/metrics/total_ecdsa_accounts.sql
@@ -1,49 +1,48 @@
-create 
-or replace function ecosystem.total_ecdsa_accounts(
-  period text, start_timestamp bigint default 0, 
-  end_timestamp bigint default CURRENT_TIMESTAMP :: timestamp9 :: bigint
-) returns setof ecosystem.metric_total language sql stable as $$ with all_entries as (
-  select  distinct on (num)
-          created_timestamp 
-  from 
-    entity 
-  where 
-    type = 'ACCOUNT' 
-    and created_timestamp between start_timestamp 
-    and end_timestamp 
-    and (
-      public_key like '02%' 
-      or public_key like '03%'
-    )
-    order  by num, created_timestamp
-), 
+create or replace function ecosystem.total_ecdsa_accounts(
+  period text,
+  start_timestamp bigint default 0,
+  end_timestamp bigint default current_timestamp::timestamp9::bigint
+) returns setof ecosystem.metric_total
+language sql stable
+as $$
+with base_total as (
+  -- Count ECDSA accounts created before the start
+  select count(*)::bigint as base
+  from (
+    select distinct on (num) num
+    from entity
+    where type = 'ACCOUNT'
+      and (public_key like '02%' or public_key like '03%')
+      and created_timestamp < start_timestamp
+    order by num, created_timestamp
+  ) t
+),
+all_entries as (
+  select distinct on (num)
+    created_timestamp
+  from entity
+  where type = 'ACCOUNT'
+    and created_timestamp between start_timestamp and end_timestamp
+    and (public_key like '02%' or public_key like '03%')
+  order by num, created_timestamp
+),
 accounts_per_period as (
-  select 
-    date_trunc(
-      period, created_timestamp :: timestamp9 :: timestamp
-    ) as period_start_timestamp, 
+  select
+    date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
     count(*) as total_ecdsa_accounts
-  from 
-    all_entries 
-  group by 
-    1 
-  order by 
-    1 asc
-) 
-select 
+  from all_entries
+  group by 1
+  order by 1 asc
+)
+select
   int8range(
-    period_start_timestamp :: timestamp9 :: bigint, 
-    (
-      lead(period_start_timestamp) over (
-        order by 
-          period_start_timestamp rows between current row 
-          and 1 following
-      )
-    ):: timestamp9 :: bigint
-  ), 
-  sum(total_ecdsa_accounts) over (
-    order by 
-      period_start_timestamp asc
-  ) as total 
-from 
-  accounts_per_period $$;
+    period_start_timestamp::timestamp9::bigint,
+    lead(period_start_timestamp) over (
+      order by period_start_timestamp
+    )::timestamp9::bigint
+  ) as timestamp_range,
+  (select base from base_total)
+    + sum(total_ecdsa_accounts) over (order by period_start_timestamp) as total
+from accounts_per_period
+order by period_start_timestamp;
+$$;

--- a/src/metrics/total_ed25519_accounts.sql
+++ b/src/metrics/total_ed25519_accounts.sql
@@ -1,46 +1,48 @@
-create 
-or replace function ecosystem.total_ed25519_accounts(
-  period text, start_timestamp bigint default 0, 
-  end_timestamp bigint default CURRENT_TIMESTAMP :: timestamp9 :: bigint
-) returns setof ecosystem.metric_total language sql stable as $$ with all_entries as (
-  select  distinct on (num)
-          created_timestamp 
-  from 
-    entity 
-  where 
-    type = 'ACCOUNT' 
-    and created_timestamp between start_timestamp 
-    and end_timestamp
+create or replace function ecosystem.total_ed25519_accounts(
+  period text,
+  start_timestamp bigint default 0,
+  end_timestamp bigint default current_timestamp::timestamp9::bigint
+) returns setof ecosystem.metric_total
+language sql stable
+as $$
+with base_total as (
+  -- Count ED25519 accounts created before the start
+  select count(*)::bigint as base
+  from (
+    select distinct on (num) num
+    from entity
+    where type = 'ACCOUNT'
+      and substring(key from 1 for 2) = E'\\x1220'
+      and created_timestamp < start_timestamp
+    order by num, created_timestamp
+  ) t
+),
+all_entries as (
+  select distinct on (num)
+    created_timestamp
+  from entity
+  where type = 'ACCOUNT'
+    and created_timestamp between start_timestamp and end_timestamp
     and substring(key from 1 for 2) = E'\\x1220'
-        order  by num, created_timestamp
-), 
+  order by num, created_timestamp
+),
 accounts_per_period as (
-  select 
-    date_trunc(
-      period, created_timestamp :: timestamp9 :: timestamp
-    ) as period_start_timestamp, 
+  select
+    date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
     count(*) as total_ed25519_accounts
-  from 
-    all_entries 
-  group by 
-    1 
-  order by 
-    1 asc
-) 
-select 
+  from all_entries
+  group by 1
+  order by 1 asc
+)
+select
   int8range(
-    period_start_timestamp :: timestamp9 :: bigint, 
-    (
-      lead(period_start_timestamp) over (
-        order by 
-          period_start_timestamp rows between current row 
-          and 1 following
-      )
-    ):: timestamp9 :: bigint
-  ), 
-  sum(total_ed25519_accounts) over (
-    order by 
-      period_start_timestamp asc
-  ) as total 
-from 
-  accounts_per_period $$;
+    period_start_timestamp::timestamp9::bigint,
+    lead(period_start_timestamp) over (
+      order by period_start_timestamp
+    )::timestamp9::bigint
+  ) as timestamp_range,
+  (select base from base_total)
+    + sum(total_ed25519_accounts) over (order by period_start_timestamp) as total
+from accounts_per_period
+order by period_start_timestamp;
+$$;

--- a/src/metrics/total_smart_contracts.sql
+++ b/src/metrics/total_smart_contracts.sql
@@ -1,44 +1,42 @@
-create 
-or replace function ecosystem.total_smart_contracts(
-  period text, start_timestamp bigint default 0, 
-  end_timestamp bigint default CURRENT_TIMESTAMP :: timestamp9 :: bigint
-) returns setof ecosystem.metric_total language sql stable as $$ with all_entries as (
-  select 
-    created_timestamp 
-  from 
-    entity 
-  where 
-    type = 'CONTRACT' 
-    and created_timestamp between start_timestamp 
-    and end_timestamp
-), 
+create or replace function ecosystem.total_smart_contracts(
+    period text,
+    start_timestamp bigint default 0,
+    end_timestamp   bigint default (current_timestamp)::timestamp9::bigint
+) returns setof ecosystem.metric_total
+language sql stable
+as $$
+  -- Count smart contracts created before the start
+with base_total as (
+    select count(*)::bigint as base
+    from   entity
+    where  type = 'CONTRACT'
+      and  created_timestamp < start_timestamp
+),
+all_entries as (
+    select created_timestamp
+    from   entity
+    where  type = 'CONTRACT'
+      and  created_timestamp between start_timestamp and end_timestamp
+),
 accounts_per_period as (
-  select 
-    date_trunc(
-      period, created_timestamp :: timestamp9 :: timestamp
-    ) as period_start_timestamp, 
-    count(*) as total_smart_contracts 
-  from 
-    all_entries 
-  group by 
-    1 
-  order by 
-    1 asc
-) 
-select 
-  int8range(
-    period_start_timestamp :: timestamp9 :: bigint, 
-    (
-      lead(period_start_timestamp) over (
-        order by 
-          period_start_timestamp rows between current row 
-          and 1 following
-      )
-    ):: timestamp9 :: bigint
-  ), 
-  sum(total_smart_contracts) over (
-    order by 
-      period_start_timestamp asc
-  ) as total 
-from 
-  accounts_per_period $$;
+    select date_trunc(
+               period, created_timestamp::timestamp9::timestamp
+           )                                as period_start_timestamp,
+           count(*)                         as smart_contracts_in_period
+    from   all_entries
+    group  by 1
+)
+select
+    int8range(
+        period_start_timestamp::timestamp9::bigint,
+        lead(period_start_timestamp) over (order by period_start_timestamp)
+             ::timestamp9::bigint
+    )                                   as timestamp_range,
+
+    (select base from base_total)
+    + sum(smart_contracts_in_period)
+          over (order by period_start_timestamp)
+        as total
+from accounts_per_period
+order by period_start_timestamp;
+$$;


### PR DESCRIPTION
issue identified: the functions were not carrying the total of the cumulative data, effectively "resetting" upon a new period. this was ultimately a limitation of the procedure.

this PR introduces new logic to the functions to sum the totals this far and carry them forward into the slices.

these have been tested and the data is live on mainnet