### PR TITLE
resolve `active_accounts` timestamp issue (functions)

### DIFF
--- a/src/jobs/load_hourly_metrics.sql
+++ b/src/jobs/load_hourly_metrics.sql
@@ -6,6 +6,18 @@ as $$
 declare
 
     metrics text[] := array [
+        'new_accounts',
+        'new_ecdsa_accounts',
+        'new_ed25519_accounts',
+        'new_smart_contracts',
+        'network_tps',
+        'network_fee',
+        'active_developer_accounts',
+        'active_retail_accounts',
+        'active_smart_contracts',
+        'active_accounts',
+        'active_ecdsa_accounts',
+        'active_ed25519_accounts',       
         'accounts_associating_nfts',
         'accounts_receiving_nfts',
         'accounts_sending_nfts',
@@ -17,17 +29,7 @@ declare
         'nfts_minted',
         'nfts_transferred',
         'nft_sales_volume',
-        'active_developer_accounts',
-        'active_retail_accounts',
-        'active_smart_contracts',
-        'active_accounts',
-        'network_fee',
-        'account_growth',
-        'network_tps',
-        'new_accounts',
-        'new_ecdsa_accounts',
-        'new_ed25519_accounts',
-        'new_smart_contracts'
+        'account_growth'
     ];
     metric_name text;
 

--- a/src/jobs/load_metrics.sql
+++ b/src/jobs/load_metrics.sql
@@ -7,10 +7,17 @@ declare
     current_period text;
 
     metrics text[] := array [
-        'active_accounts',
+        'total_accounts',
+        'total_ecdsa_accounts',
+        'total_ed25519_accounts',
+        'total_smart_contracts',
+        'avg_usd_conversion',
         'active_developer_accounts',
         'active_retail_accounts',
         'active_smart_contracts',
+        'active_accounts',
+        'active_ecdsa_accounts',
+        'active_ed25519_accounts',
         'accounts_associating_nfts',
         'accounts_receiving_nfts',
         'accounts_sending_nfts',
@@ -21,12 +28,7 @@ declare
         'nft_collections_created',
         'nfts_minted',
         'nfts_transferred',
-        'nft_sales_volume',
-        'avg_usd_conversion',
-        'total_accounts',
-        'total_ecdsa_accounts',
-        'total_ed25519_accounts',
-        'total_smart_contracts'
+        'nft_sales_volume'
     ];
     metric text;
 

--- a/src/metrics/active_accounts.sql
+++ b/src/metrics/active_accounts.sql
@@ -1,29 +1,41 @@
-create or replace function ecosystem.active_accounts(
-    period text,
-    start_timestamp bigint default 0,
-    end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
+CREATE OR REPLACE FUNCTION ecosystem.active_accounts(
+    period TEXT,
+    start_timestamp BIGINT DEFAULT 0,
+    end_timestamp   BIGINT DEFAULT CURRENT_TIMESTAMP::timestamp9::BIGINT
 )
-returns setof ecosystem . metric_total
-as $$
-with active_accounts as (
-  select *
-    from ecosystem.active_developer_accounts(period, start_timestamp, end_timestamp)
-  union all select *
-    from ecosystem.active_retail_accounts(period, start_timestamp, end_timestamp)
-  union all select *
-    from ecosystem.active_smart_contracts(period, start_timestamp, end_timestamp)
+RETURNS SETOF ecosystem.metric_total
+AS $$
+WITH active_accounts AS (
+    SELECT * FROM ecosystem.active_developer_accounts(period, start_timestamp, end_timestamp)
+    UNION ALL
+    SELECT * FROM ecosystem.active_retail_accounts  (period, start_timestamp, end_timestamp)
+    UNION ALL
+    SELECT * FROM ecosystem.active_smart_contracts  (period, start_timestamp, end_timestamp)
 ),
-merged_data as (
-    select lower(int8range) as period_start_timestamp, sum(total) as total
-  from active_accounts d
-  group by 1
-  order by 1 desc
+merged_data AS (
+    SELECT
+        DATE_TRUNC(
+            period,
+            (LOWER(int8range))::timestamp9::timestamp
+        )                         AS period_start,
+        SUM(total)                AS total
+    FROM   active_accounts
+    GROUP  BY 1
 )
-select
-    int8range(
-        period_start_timestamp::timestamp9::bigint,
-        coalesce((lead(period_start_timestamp) over (order by period_start_timestamp rows between current row and 1 following))::timestamp9::bigint, end_timestamp)
+SELECT
+    INT8RANGE(
+        period_start::timestamp9::BIGINT,
+        (CASE period
+            WHEN 'hour'    THEN period_start + INTERVAL '1 hour'
+            WHEN 'day'     THEN period_start + INTERVAL '1 day'
+            WHEN 'week'    THEN period_start + INTERVAL '1 week'
+            WHEN 'month'   THEN period_start + INTERVAL '1 month'
+            WHEN 'quarter' THEN period_start + INTERVAL '3 months'
+            WHEN 'year'    THEN period_start + INTERVAL '1 year'
+            ELSE period_start + INTERVAL '1 day'
+         END)::timestamp9::BIGINT
     ),
     total
-from merged_data
-$$ language sql stable;
+FROM   merged_data
+ORDER  BY period_start DESC;
+$$ LANGUAGE sql STABLE;

--- a/src/metrics/active_accounts.sql
+++ b/src/metrics/active_accounts.sql
@@ -37,5 +37,16 @@ SELECT
     ),
     total
 FROM   merged_data
+WHERE  (
+        CASE period
+          WHEN 'hour'    THEN period_start + INTERVAL '1 hour'
+          WHEN 'day'     THEN period_start + INTERVAL '1 day'
+          WHEN 'week'    THEN period_start + INTERVAL '1 week'
+          WHEN 'month'   THEN period_start + INTERVAL '1 month'
+          WHEN 'quarter' THEN period_start + INTERVAL '3 months'
+          WHEN 'year'    THEN period_start + INTERVAL '1 year'
+          ELSE period_start + INTERVAL '1 day'
+        END
+       ) <= CURRENT_TIMESTAMP 
 ORDER  BY period_start DESC;
 $$ LANGUAGE sql STABLE;


### PR DESCRIPTION
Issue: The daily-and-larger rows show odd, duplicated timestamps because lead() is applied twice—first inside each sub-function and again after the union—so upper(timestamp_range) lands on “the next row that exists” instead of the true period boundary. 

Solution: Removing the second lead() (or computing the upper bound as period-start + 1 interval) will align every range’s upper edge to the exact 00:00:00.000000000 cutoff and eliminate duplicates.