### PR TITLE
Exclude Contract Accounts From New Account Metrics in ecosystem.new_accounts()

### DIFF
--- a/src/metrics/new_accounts.sql
+++ b/src/metrics/new_accounts.sql
@@ -1,32 +1,37 @@
-create or replace function ecosystem.new_accounts(
-  period text,
-  start_timestamp bigint default 0,
-  end_timestamp bigint default CURRENT_TIMESTAMP::timestamp9::bigint
+CREATE OR REPLACE FUNCTION ecosystem.new_accounts (
+  period             public.interval_granularity,
+  start_timestamp    BIGINT DEFAULT 0, 
+  end_timestamp      BIGINT DEFAULT
+    (extract(epoch FROM current_timestamp) * 1e9)::BIGINT
 )
-returns setof ecosystem . metric_total
-language sql stable
-as $$
-
-with all_entries as (
-  select created_timestamp
-  from entity
-  where type = 'ACCOUNT'
-  and created_timestamp between start_timestamp and end_timestamp
+RETURNS TABLE (timestamp_range INT8RANGE, total BIGINT)
+LANGUAGE SQL STABLE
+AS $$
+WITH all_entries AS (
+  SELECT created_timestamp
+  FROM public.entity
+  WHERE type = 'ACCOUNT'
+    AND created_timestamp BETWEEN start_timestamp AND end_timestamp
+    AND key IS NOT NULL
+    AND encode(key, 'hex') <> '3200'
 ),
-accounts_per_period as (
-  select date_trunc(period, created_timestamp::timestamp9::timestamp) as period_start_timestamp,
-  count(*) as total
-  from all_entries
-  group by 1
-  order by 1 asc
+periodized AS (
+  SELECT
+    date_trunc(period::TEXT,
+               to_timestamp(created_timestamp / 1e9)) AS period_start,
+    COUNT(*) AS total
+  FROM all_entries
+  GROUP BY 1
+  ORDER BY 1
 )
-select
-int8range(
-  period_start_timestamp::timestamp9::bigint,
-  (lead(period_start_timestamp) over (order by period_start_timestamp rows between current row and 1 following))::timestamp9::bigint
-),
-total
-
-from accounts_per_period
-
+SELECT
+  int8range(
+    (extract(epoch FROM period_start) * 1e9)::BIGINT,
+    COALESCE(
+      (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
+      end_timestamp + 1 
+    )
+  ) AS timestamp_range,
+  total
+FROM periodized;
 $$;


### PR DESCRIPTION
**Issue:**
The original `new_accounts` function overcounted by including contract accounts and other non-user accounts that do not have real cryptographic keys.

**Solution:**
The function was updated to exclude entries where the `key` field is null or equals `\x3200`, ensuring only genuine user-controlled accounts are counted.

**Testing:**
Data output returns as expected. Job running on mainnet to test GraphQL output.