### PR TITLE
Fix job comment for metrics year SQL

### DIFF
--- a/src/v2/jobs/load_metrics_year.sql
+++ b/src/v2/jobs/load_metrics_year.sql
@@ -7,7 +7,7 @@ create or replace procedure ecosystem.load_metrics_year(out summary jsonb defaul
 language plpgsql
 as $$
 declare
-    periods constant text[] := array['year'];      -- Quarter (the period for this job)
+    periods constant text[] := array['year'];      -- Year (the period for this job)
     metrics constant text[] := array[
         'total_accounts',
         'total_ecdsa_accounts',


### PR DESCRIPTION
## Summary
- fix the comment on the `periods` constant in `load_metrics_year.sql`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686812b00d0883229b31934a5b97d425