### PR TITLE
Fix timestamp9 extension typo

### DIFF
--- a/src/up.sql
+++ b/src/up.sql
@@ -3,7 +3,7 @@ create schema if not exists ecosystem;
 -- https://github.com/citusdata/pg_cron
 create extension if not exists pg_cron;
 -- https://github.com/optiver/timestamp9
-create extention if not exists timestamp9;
+create extension if not exists timestamp9;
 -- https://github.com/pramsey/pgsql-http
 create extension if not exists http;
 


### PR DESCRIPTION
## Summary
- correct the `create extension` command for `timestamp9`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686812e64ca0832285f0c735fb369af0