### PR TITLE
Fix metric loader procedures to align intervals with period boundaries

### DIFF
--- a/src/jobs/load_metrics_day.sql
+++ b/src/jobs/load_metrics_day.sql
@@ -35,12 +35,16 @@ declare
     period_loop_time timestamp;
 
     starting_timestamp bigint := 0;
+    end_timestamp_bigint bigint;
     processed_metrics int := 0;
     errors jsonb := '[]'::jsonb;
 
 begin
     set time zone 'UTC';
     total_time := clock_timestamp();
+
+    -- Always truncate to the start of the current day in UTC
+    end_timestamp_bigint := date_trunc('day', now())::timestamp9::bigint;
 
     -- Loop through each metric and period
     foreach metric in array metrics loop
@@ -67,10 +71,10 @@ begin
                 execute format(
                     'insert into ecosystem.metric (name, period, timestamp_range, total)
                      select %L as name, %L as period, int8range as timestamp_range, total
-                     from ecosystem.%I(%L::text, %L::bigint) 
+                     from ecosystem.%I(%L::text, %L::bigint, %L::bigint)
                      where upper(int8range) is not null
                      on conflict (name, period, timestamp_range) do update set total = EXCLUDED.total',
-                    metric, current_period, metric, current_period, starting_timestamp
+                    metric, current_period, metric, current_period, starting_timestamp, end_timestamp_bigint
                 );
 
                 processed_metrics := processed_metrics + 1;

--- a/src/jobs/load_metrics_init.sql
+++ b/src/jobs/load_metrics_init.sql
@@ -9,7 +9,7 @@ as $$
 declare
     periods constant text[] := array['day', 'week'];      -- Enter desired periods
     metrics constant text[] := array[
-        'ADD_METRIC',
+    --  'ADD_METRIC',
     ];                                                    -- Metrics to initialize
     current_period text;
     metric text;
@@ -19,6 +19,7 @@ declare
     period_loop_time timestamp;
 
     starting_timestamp bigint := 0;
+    end_timestamp_bigint bigint;
     processed_metrics int := 0;
     errors jsonb := '[]'::jsonb;
 
@@ -29,6 +30,9 @@ begin
     -- Loop through each metric and period
     foreach metric in array metrics loop
         metric_loop_time := clock_timestamp();
+
+        -- Truncate now() to correct period for end bound
+        end_timestamp_bigint := date_trunc(current_period, now())::timestamp9::bigint;
 
         foreach current_period in array periods loop
             period_loop_time := clock_timestamp();
@@ -51,10 +55,10 @@ begin
                 execute format(
                     'insert into ecosystem.metric (name, period, timestamp_range, total)
                      select %L as name, %L as period, int8range as timestamp_range, total
-                     from ecosystem.%I(%L::text, %L::bigint) 
+                     from ecosystem.%I(%L::text, %L::bigint, %L::bigint)
                      where upper(int8range) is not null
                      on conflict (name, period, timestamp_range) do update set total = EXCLUDED.total',
-                    metric, current_period, metric, current_period, starting_timestamp
+                    metric, current_period, metric, current_period, starting_timestamp, end_timestamp_bigint
                 );
 
                 processed_metrics := processed_metrics + 1;

--- a/src/jobs/load_metrics_month.sql
+++ b/src/jobs/load_metrics_month.sql
@@ -28,12 +28,16 @@ declare
     period_loop_time timestamp;
 
     starting_timestamp bigint := 0;
+    end_timestamp_bigint bigint;
     processed_metrics int := 0;
     errors jsonb := '[]'::jsonb;
 
 begin
     set time zone 'UTC';
     total_time := clock_timestamp();
+
+    -- Always truncate to the start of the current month in UTC
+    end_timestamp_bigint := date_trunc('month', now())::timestamp9::bigint;
 
     -- Loop through each metric and period
     foreach metric in array metrics loop
@@ -60,10 +64,10 @@ begin
                 execute format(
                     'insert into ecosystem.metric (name, period, timestamp_range, total)
                      select %L as name, %L as period, int8range as timestamp_range, total
-                     from ecosystem.%I(%L::text, %L::bigint) 
+                     from ecosystem.%I(%L::text, %L::bigint, %L::bigint)
                      where upper(int8range) is not null
                      on conflict (name, period, timestamp_range) do update set total = EXCLUDED.total',
-                    metric, current_period, metric, current_period, starting_timestamp
+                    metric, current_period, metric, current_period, starting_timestamp, end_timestamp_bigint
                 );
 
                 processed_metrics := processed_metrics + 1;

--- a/src/jobs/load_metrics_quarter.sql
+++ b/src/jobs/load_metrics_quarter.sql
@@ -28,12 +28,15 @@ declare
     period_loop_time timestamp;
 
     starting_timestamp bigint := 0;
+    end_timestamp_bigint bigint;
     processed_metrics int := 0;
     errors jsonb := '[]'::jsonb;
 
 begin
     set time zone 'UTC';
     total_time := clock_timestamp();
+    -- Always truncate to the start of the current quarter in UTC
+    end_timestamp_bigint := date_trunc('quarter', now())::timestamp9::bigint;
 
     -- Loop through each metric and period
     foreach metric in array metrics loop
@@ -60,10 +63,10 @@ begin
                 execute format(
                     'insert into ecosystem.metric (name, period, timestamp_range, total)
                      select %L as name, %L as period, int8range as timestamp_range, total
-                     from ecosystem.%I(%L::text, %L::bigint) 
+                     from ecosystem.%I(%L::text, %L::bigint, %L::bigint)
                      where upper(int8range) is not null
                      on conflict (name, period, timestamp_range) do update set total = EXCLUDED.total',
-                    metric, current_period, metric, current_period, starting_timestamp
+                    metric, current_period, metric, current_period, starting_timestamp, end_timestamp_bigint
                 );
 
                 processed_metrics := processed_metrics + 1;

--- a/src/jobs/load_metrics_week.sql
+++ b/src/jobs/load_metrics_week.sql
@@ -28,12 +28,16 @@ declare
     period_loop_time timestamp;
 
     starting_timestamp bigint := 0;
+    end_timestamp_bigint bigint;
     processed_metrics int := 0;
     errors jsonb := '[]'::jsonb;
 
 begin
     set time zone 'UTC';
     total_time := clock_timestamp();
+
+    -- Always truncate to the start of the current week in UTC
+    end_timestamp_bigint := date_trunc('week', now())::timestamp9::bigint;
 
     -- Loop through each metric and period
     foreach metric in array metrics loop
@@ -60,10 +64,10 @@ begin
                 execute format(
                     'insert into ecosystem.metric (name, period, timestamp_range, total)
                      select %L as name, %L as period, int8range as timestamp_range, total
-                     from ecosystem.%I(%L::text, %L::bigint) 
+                     from ecosystem.%I(%L::text, %L::bigint, %L::bigint)
                      where upper(int8range) is not null
                      on conflict (name, period, timestamp_range) do update set total = EXCLUDED.total',
-                    metric, current_period, metric, current_period, starting_timestamp
+                    metric, current_period, metric, current_period, starting_timestamp, end_timestamp_bigint
                 );
 
                 processed_metrics := processed_metrics + 1;

--- a/src/jobs/load_metrics_year.sql
+++ b/src/jobs/load_metrics_year.sql
@@ -28,12 +28,16 @@ declare
     period_loop_time timestamp;
 
     starting_timestamp bigint := 0;
+    end_timestamp_bigint bigint;
     processed_metrics int := 0;
     errors jsonb := '[]'::jsonb;
 
 begin
     set time zone 'UTC';
     total_time := clock_timestamp();
+
+    -- Always truncate to the start of the current year in UTC
+    end_timestamp_bigint := date_trunc('year', now())::timestamp9::bigint;
 
     -- Loop through each metric and period
     foreach metric in array metrics loop
@@ -60,10 +64,10 @@ begin
                 execute format(
                     'insert into ecosystem.metric (name, period, timestamp_range, total)
                      select %L as name, %L as period, int8range as timestamp_range, total
-                     from ecosystem.%I(%L::text, %L::bigint) 
+                     from ecosystem.%I(%L::text, %L::bigint, %L::bigint)
                      where upper(int8range) is not null
                      on conflict (name, period, timestamp_range) do update set total = EXCLUDED.total',
-                    metric, current_period, metric, current_period, starting_timestamp
+                    metric, current_period, metric, current_period, starting_timestamp, end_timestamp_bigint
                 );
 
                 processed_metrics := processed_metrics + 1;


### PR DESCRIPTION
* All `ecosystem.load_metrics_*` procedures now truncate `end_timestamp` to the correct period boundary (`hour`, `day`, `week`, `month`, `quarter`, `year`) using `date_trunc`.
* Updated procedure logic to pass the correct upper bound as the third argument to metric SQL functions, ensuring all metric intervals are cleanly aligned (e.g., no more off-hour rows like `21:01:00`).
* Adjusted comments for clarity and improved code formatting.

this resolved an issue that affected `network_fee` and no other functions were effected, but this will prevent the issue from happening in the future.