### PR TITLE
fix: 1 nano second bug

### DIFF
--- a/src/jobs/load_metrics_init.sql
+++ b/src/jobs/load_metrics_init.sql
@@ -9,7 +9,9 @@ as $$
 declare
     periods constant text[] := array['day', 'week', 'month'];      -- Hour (the period for this job)
     metrics constant text[] := array[
-        'new_crypto_transactions'
+          'new_hfs_transactions',
+          'new_transactions',
+          'new_hcs_transactions'
     ];                                             -- Metrics (functions for this job)
     current_period text;
     metric text;

--- a/src/jobs/load_metrics_init.sql
+++ b/src/jobs/load_metrics_init.sql
@@ -7,11 +7,9 @@ create or replace procedure ecosystem.load_metrics_init()
 language plpgsql
 as $$
 declare
-    periods constant text[] := array['day'];      -- Hour (the period for this job)
+    periods constant text[] := array['day', 'week', 'month'];      -- Hour (the period for this job)
     metrics constant text[] := array[
-        'total_transactions',
-        'total_hcs_transactions',
-        'total_crypto_transactions'
+        'new_crypto_transactions'
     ];                                             -- Metrics (functions for this job)
     current_period text;
     metric text;

--- a/src/metrics/transactions/light/total_crypto_transactions_light.sql
+++ b/src/metrics/transactions/light/total_crypto_transactions_light.sql
@@ -52,7 +52,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/light/total_hcs_transactions_light.sql
+++ b/src/metrics/transactions/light/total_hcs_transactions_light.sql
@@ -52,7 +52,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/light/total_transactions_light.sql
+++ b/src/metrics/transactions/light/total_transactions_light.sql
@@ -53,7 +53,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/new_crypto_transactions.sql
+++ b/src/metrics/transactions/new_crypto_transactions.sql
@@ -25,7 +25,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/new_hcs_transactions.sql
+++ b/src/metrics/transactions/new_hcs_transactions.sql
@@ -27,7 +27,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/new_hfs_transactions.sql
+++ b/src/metrics/transactions/new_hfs_transactions.sql
@@ -25,7 +25,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/new_hscs_transactions.sql
+++ b/src/metrics/transactions/new_hscs_transactions.sql
@@ -25,7 +25,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/new_hts_transactions.sql
+++ b/src/metrics/transactions/new_hts_transactions.sql
@@ -25,7 +25,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/new_other_transactions.sql
+++ b/src/metrics/transactions/new_other_transactions.sql
@@ -25,7 +25,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/new_transactions.sql
+++ b/src/metrics/transactions/new_transactions.sql
@@ -26,7 +26,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/total_crypto_transactions.sql
+++ b/src/metrics/transactions/total_crypto_transactions.sql
@@ -30,7 +30,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/total_hcs_transactions.sql
+++ b/src/metrics/transactions/total_hcs_transactions.sql
@@ -32,7 +32,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/total_hfs_transactions.sql
+++ b/src/metrics/transactions/total_hfs_transactions.sql
@@ -30,7 +30,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/total_hscs_transactions.sql
+++ b/src/metrics/transactions/total_hscs_transactions.sql
@@ -30,7 +30,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/total_hts_transactions.sql
+++ b/src/metrics/transactions/total_hts_transactions.sql
@@ -30,7 +30,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/total_other_transactions.sql
+++ b/src/metrics/transactions/total_other_transactions.sql
@@ -30,7 +30,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total

--- a/src/metrics/transactions/total_transactions.sql
+++ b/src/metrics/transactions/total_transactions.sql
@@ -31,7 +31,7 @@ SELECT int8range(
          (extract(epoch FROM period_start) * 1e9)::BIGINT,
          COALESCE(
            (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
-           end_timestamp + 1
+           end_timestamp
          )
        ) AS int8range,
        total


### PR DESCRIPTION
this was a bug that effected transaction metrics and caused some periods to be incorrectly calculated. the issue was a simple tweak, but the was data that had to be surgically removed and re-backfilled to avoid excessive compute,

all data has been fixed, new functions are running and things look good.