### PR TITLE
Add HBAR total supply metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to the Hedera Stats project since August 1, 2024.
 
-## [Unreleased] - 2025-08-14
+## [Unreleased] - 2025-09-26
 
 ### Added
 
+- HBAR total supply metric (50 billion constant) in hbar-defi category
 - ECDSA accounts with real EVM addresses metric (#51)
 - New folder structure for better organization (#52)
 - Transaction metrics with simplified categorization (#47)

--- a/src/metric_descriptions.sql
+++ b/src/metric_descriptions.sql
@@ -1,6 +1,7 @@
 insert into ecosystem.metric_description (name, description, methodology)
 values
     -- HBAR & DeFi
+    ('hbar_total_supply', 'The total supply of HBAR tokens pre-minted at network genesis (50 billion HBAR).', 'Fixed supply of 50 billion HBAR (5,000,000,000,000,000,000 tinybars) as defined in the Hedera protocol. This value is hardcoded in the Mirror Node and cannot change without unanimous consent of the Hedera Council. Note: Summing all entity balances yields 49,999,943,600 HBAR due to 56,400 HBAR existing at protocol level outside any account.'),
     ('avg_usd_conversion', 'Aggregates the latest price of HBAR from multiple sources, making it crucial for real-time tracking and analyzing price trends.', 'The average of candlestick closing prices for a given period for the HBAR/USDT pair on the five major exchanges by trading volume (Binance, Bybit, OKX, Bitget and MEXC) was calculated. The price is multiplied by 10,000 for integer representation for each time period.'),
     ('network_tvl', 'Total Value Locked (TVL) represents the total amount of assets locked within decentralized finance (DeFi) protocols on the Hedera network, as reported by DeFi Llama.', 'Uses data from the DeFiLlama API to record the total USD value locked in Hedera DeFi protocols each day.'),
     ('stablecoin_marketcap', 'Tracks the market capitalization of stablecoins circulating on the Hedera network as reported by DeFiLlama.', 'Fetches stablecoin circulation data from DeFiLlama and uses the peggedUSD value to record the stablecoin market cap (USD) for each day.'),

--- a/src/metrics/hbar-defi/hbar_total_supply.sql
+++ b/src/metrics/hbar-defi/hbar_total_supply.sql
@@ -1,0 +1,62 @@
+-- =====================================================
+-- HBAR Total Supply Metric
+-- =====================================================
+-- Purpose: Insert the total HBAR supply (50 billion) into ecosystem.metric table
+--
+-- Context:
+--   - Hedera pre-minted exactly 50 billion HBAR at network genesis
+--   - This value is hardcoded in the Mirror Node (NetworkSupplyViewModel.totalSupply)
+--   - The total supply cannot change without unanimous consent of the Hedera Council
+--   - Note: Summing all entity balances yields 49,999,943,600 HBAR (missing 56,400 HBAR)
+--           The missing amount appears to exist at protocol level, outside any account
+--
+-- Implementation:
+--   - Creates 6 rows (one per time period) for user query flexibility
+--   - Users can query with any period (minute, hour, day, week, month, year)
+--   - Ideally users do not use a period when querying
+--   - Timestamp range represents validity period (genesis to future date)
+--   - Upper bound can be interpreted as "last verified"
+--
+-- Usage:
+--   Run this INSERT to populate/update the metric
+--   Query with: SELECT total FROM ecosystem.metric WHERE name = 'hbar_total_supply' AND period = 'day'
+-- =====================================================
+
+WITH supply AS (
+    SELECT
+        5000000000000000000 AS total,  -- 50 billion HBAR in tinybars (1 HBAR = 100,000,000 tinybars)
+        '[1567296000000000000, 2000000000000000000)'::int8range AS range  -- Sept 1, 2019 (genesis)
+)
+INSERT INTO ecosystem.metric (name, period, timestamp_range, total)
+SELECT
+    'hbar_total_supply' AS name,
+    p.period,
+    s.range,
+    s.total
+FROM supply s
+CROSS JOIN (VALUES
+    ('minute'),   -- Minute granularity
+    ('hour'),     -- Hour granularity
+    ('day'),      -- Day granularity (most common)
+    ('week'),     -- Week granularity
+    ('month'),    -- Month granularity
+    ('quarter'),  -- Year granularity
+    ('year')      -- Year granularity
+) AS p(period)
+ON CONFLICT (name, period, timestamp_range)
+DO UPDATE SET total = EXCLUDED.total;  -- Ensures idempotency: safe to run multiple times
+
+-- =====================================================
+-- Test Query
+-- =====================================================
+-- To verify the insert and get total supply in different units:
+
+-- SELECT
+--     total AS total_tinybars,
+--     total / 100000000.0 AS total_hbar,
+--     total / 100000000.0 / 1000000000.0 AS total_billion_hbar
+-- FROM ecosystem.metric
+-- WHERE name = 'hbar_total_supply'
+-- LIMIT 1;
+
+-- Expected result: 50.0 billion HBAR


### PR DESCRIPTION
## Summary
This PR adds a new static metric for HBAR total supply (50 billion constant) to the hedera-stats ecosystem.

## Changes
- Added `hbar_total_supply.sql` in the `metrics/hbar-defi` category
- Added metric description and methodology to `metric_descriptions.sql`
- Updated `CHANGELOG.md` to document the addition

## Details
The metric represents the fixed total supply of 50 billion HBAR pre-minted at network genesis. This value:
- Is hardcoded in the Mirror Node (`NetworkSupplyViewModel.totalSupply`)
- Cannot change without unanimous consent of the Hedera Council
- Is available across all time periods (minute, hour, day, week, month, quarter, year)

### Note on Implementation
There is a known discrepancy where summing all entity balances yields 49,999,943,600 HBAR (missing 56,400 HBAR). This 56,400 HBAR exists at the protocol level outside any account, which is why we use the hardcoded constant of exactly 50 billion.

## Testing
The SQL query has been tested and simply inserts the constant value into `ecosystem.metric` table for all periods.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update