### PR TITLE
fix: correct misleading comments in load_metrics_init.sql

### DIFF
--- a/src/jobs/load_metrics_init.sql
+++ b/src/jobs/load_metrics_init.sql
@@ -1,5 +1,5 @@
 ----------------------------------------------------
--- LOAD METRICS HOUR / HEDERASTATS.com / HGRAPH.com
+-- LOAD METRICS INIT / HEDERASTATS.com / HGRAPH.com
 -- Automates upsert of metrics into ecosystem.metric
 ----------------------------------------------------
 
@@ -7,7 +7,7 @@ create or replace procedure ecosystem.load_metrics_init()
 language plpgsql
 as $$
 declare
-    periods constant text[] := array['day', 'week', 'month', 'quarter', 'year'];      -- Hour (the period for this job)
+    periods constant text[] := array['day', 'week', 'month', 'quarter', 'year'];      -- All periods (for initialization)
     metrics constant text[] := array[
           'hbar_total_released'
     ];                                             -- Metrics (functions for this job)


### PR DESCRIPTION
Fixes misleading comments in the load_metrics_init procedure.

The header comment incorrectly said 'LOAD METRICS HOUR' when the procedure actually processes all periods.
The inline comment also incorrectly referenced 'Hour' when it lists all periods.

This is a documentation fix only - no functional changes.