### PR TITLE
fix: Top tokens tables

### DIFF
--- a/src/metrics/non-fungible-tokens/top_non_fungible_tokens_erc.sql
+++ b/src/metrics/non-fungible-tokens/top_non_fungible_tokens_erc.sql
@@ -12,13 +12,13 @@
 --   - Excludes collections where top 5 accounts contribute >threshold of transactions
 -- Methodology: https://docs.hgraph.com/hedera-stats-wip/top-50-non-fungible-tokens
 
--- Drop existing type and function if they exist
-DROP TYPE IF EXISTS ecosystem._top_non_fungible_tokens_erc CASCADE;
-DROP FUNCTION IF EXISTS ecosystem.top_non_fungible_tokens_erc(integer, integer, numeric) CASCADE;
-DROP FUNCTION IF EXISTS ecosystem.top_non_fungible_tokens_erc(integer, integer) CASCADE;
+-- EXAMPLE QUERY: Top Non-Fungible Token Collections (ERC)
 
--- Create custom return type
-CREATE TYPE ecosystem._top_non_fungible_tokens_erc AS (
+-- SELECT * FROM ecosystem.top_non_fungible_tokens_erc();
+
+-- CREATE TABLE: Top Non-Fungible Token Collections (ERC)
+
+CREATE TABLE ecosystem._top_non_fungible_tokens_erc (
     rank integer,                      -- Position in ranking (1 = highest score)
     token_id bigint,                   -- ERC-721 contract token_id
     token_evm_address text,            -- EVM address of the contract (0x...)

--- a/src/metrics/non-fungible-tokens/top_non_fungible_tokens_hts.sql
+++ b/src/metrics/non-fungible-tokens/top_non_fungible_tokens_hts.sql
@@ -9,13 +9,13 @@
 --   - Excludes collections where top 5 accounts contribute >threshold of transactions
 -- Methodology: https://docs.hgraph.com/hedera-stats-wip/top-50-non-fungible-tokens
 
--- Drop existing type and function if they exist
-DROP TYPE IF EXISTS ecosystem._top_non_fungible_tokens_hts CASCADE;
-DROP FUNCTION IF EXISTS ecosystem.top_non_fungible_tokens_hts(integer, integer, numeric) CASCADE;
-DROP FUNCTION IF EXISTS ecosystem.top_non_fungible_tokens_hts(integer, integer) CASCADE;
+-- EXAMPLE QUERY: Top Non-Fungible Token Collections (HTS)
 
--- Create custom return type
-CREATE TYPE ecosystem._top_non_fungible_tokens_hts AS (
+-- SELECT * FROM ecosystem.top_non_fungible_tokens_hts();
+
+-- CREATE TABLE: Top Non-Fungible Token Collections (HTS)
+
+CREATE TABLE ecosystem._top_non_fungible_tokens_hts (
     rank integer,                      -- Position in ranking (1 = highest score)
     token_id bigint,                   -- Hedera token ID
     collection_name text,              -- Name of the NFT collection


### PR DESCRIPTION
# Description 
Convert ecosystem._top_non_fungible_tokens_hts and _top_non_fungible_tokens_erc
from composite types to real backing tables.

PostgreSQL auto-creates a row type for every table, so all RETURNS SETOF
signatures remain valid without modification.

## Changes per file:
- DROP TYPE ... CASCADE → no DROP (matches nft_collection_sales_volume pattern)
- CREATE TYPE ... AS (...) → CREATE TABLE ... (...)

## Affected files:
 - src/metrics/non-fungible-tokens/top_non_fungible_tokens_erc.sql
 - src/metrics/non-fungible-tokens/top_non_fungible_tokens_hts.sql