### PR TITLE
Upgrade nft_collections_created metric from legacy to active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Hedera Stats project since August 1, 2024.
 
 ### Added
 
+- NFT collections created metric upgraded from legacy to active with proper methodology, added to all load procedures (hour, day, week, month, quarter, year)
 - Average network fee metric (avg_network_fee) to calculate mean transaction fee cost per period
 - Average gas used metrics: avg_gas_used (all types), avg_gas_used_contract_call, avg_gas_used_ethereum_tx, avg_gas_used_contract_create
 - Daily period support for avg_time_to_consensus metric with automated ETL pipeline

--- a/src/jobs/load_metrics_day.sql
+++ b/src/jobs/load_metrics_day.sql
@@ -43,6 +43,7 @@ declare
         'new_hts_transactions',
         'new_crypto_transactions',
         'new_other_transactions',
+        'nft_collections_created',
         'total_transactions', -- light
         'total_hcs_transactions', -- light
         'total_crypto_transactions', -- light

--- a/src/jobs/load_metrics_hour.sql
+++ b/src/jobs/load_metrics_hour.sql
@@ -36,7 +36,8 @@ declare
         'new_hscs_transactions',
         'new_hts_transactions',
         'new_crypto_transactions',
-        'new_other_transactions'
+        'new_other_transactions',
+        'nft_collections_created'
     ];                                             -- Metrics (functions for this job)
     current_period text;
     metric text;

--- a/src/jobs/load_metrics_month.sql
+++ b/src/jobs/load_metrics_month.sql
@@ -34,6 +34,7 @@ declare
         'new_hts_transactions',
         'new_crypto_transactions',
         'new_other_transactions',
+        'nft_collections_created',
         'total_transactions', -- light
         'total_hcs_transactions', -- light
         'total_crypto_transactions', -- light

--- a/src/jobs/load_metrics_quarter.sql
+++ b/src/jobs/load_metrics_quarter.sql
@@ -33,6 +33,7 @@ declare
         'new_hts_transactions',
         'new_crypto_transactions',
         'new_other_transactions',
+        'nft_collections_created',
         'total_transactions', -- light
         'total_hcs_transactions', -- light
         'total_crypto_transactions', -- light

--- a/src/jobs/load_metrics_week.sql
+++ b/src/jobs/load_metrics_week.sql
@@ -34,6 +34,7 @@ declare
         'new_hts_transactions',
         'new_crypto_transactions',
         'new_other_transactions',
+        'nft_collections_created',
         'total_transactions', -- light
         'total_hcs_transactions', -- light
         'total_crypto_transactions', -- light

--- a/src/jobs/load_metrics_year.sql
+++ b/src/jobs/load_metrics_year.sql
@@ -33,6 +33,7 @@ declare
         'new_hts_transactions',
         'new_crypto_transactions',
         'new_other_transactions',
+        'nft_collections_created',
         'total_transactions', -- light
         'total_hcs_transactions', -- light
         'total_crypto_transactions', -- light

--- a/src/metric_descriptions.sql
+++ b/src/metric_descriptions.sql
@@ -71,7 +71,7 @@ values
     ('accounts_creating_nft_collections', 'Number of accounts that created NFT collections during the period', ''),
     ('active_nft_accounts', 'Number of active NFT accounts during the period', ''),
     ('active_nft_builder_accounts', 'Number of active NFT builder accounts during the period', ''),
-    ('nft_collections_created', 'Number of NFT collections created during the period', ''),
+    ('nft_collections_created', 'Tracks the number of new NFT collections (non-fungible token types) created on Hedera within a specific time period.', 'Counts distinct token_id entries from the token table where type is NON_FUNGIBLE_UNIQUE and created_timestamp falls within the specified period. Each unique token_id represents one NFT collection. Results are grouped by the truncated period start time.'),
     ('nfts_minted', 'Number of NFTs minted during the period', ''),
     ('nfts_transferred', 'Number of NFTs transferred during the period', ''),
     ('nft_sales_volume', 'Volume of NFT sales during the period', '')

--- a/src/metrics/non-fungible-tokens/nft_collections_created.sql
+++ b/src/metrics/non-fungible-tokens/nft_collections_created.sql
@@ -1,0 +1,31 @@
+CREATE OR REPLACE FUNCTION ecosystem.nft_collections_created (
+  period             public.interval_granularity,
+  start_timestamp    BIGINT DEFAULT 0,
+  end_timestamp      BIGINT DEFAULT
+    (extract(epoch FROM current_timestamp) * 1e9)::BIGINT
+)
+RETURNS TABLE (timestamp_range INT8RANGE, total BIGINT)
+LANGUAGE SQL STABLE
+AS $$
+WITH periodized AS (
+  SELECT
+    date_trunc(period::TEXT,
+               to_timestamp(created_timestamp / 1e9)) AS period_start,
+    COUNT(DISTINCT token_id) AS total
+  FROM public.token
+  WHERE type = 'NON_FUNGIBLE_UNIQUE'
+    AND created_timestamp BETWEEN start_timestamp AND end_timestamp
+  GROUP BY 1
+  ORDER BY 1
+)
+SELECT
+  int8range(
+    (extract(epoch FROM period_start) * 1e9)::BIGINT,
+    COALESCE(
+      (extract(epoch FROM LEAD(period_start) OVER (ORDER BY period_start)) * 1e9)::BIGINT,
+      end_timestamp + 1
+    )
+  ) AS timestamp_range,
+  total
+FROM periodized;
+$$;


### PR DESCRIPTION
## Summary

- Upgraded `nft_collections_created` from legacy to the modern metric pattern (matching `new_accounts` style with `interval_granularity`, `RETURNS TABLE`, `to_timestamp`/`extract` timestamp handling)
- Added metric to all load procedures: hour, day, week, month, quarter, year
- Updated metric description with documented methodology

## Test plan

- [x] Deploy function to testnet: `CREATE OR REPLACE FUNCTION ecosystem.nft_collections_created(...)`
- [x] Verify output: `SELECT * FROM ecosystem.nft_collections_created('day', (now() - INTERVAL '7 days')::timestamp9::bigint);`
- [x] Run `CALL ecosystem.load_metrics_day();` and confirm data populates in `ecosystem.metric`
- [x] Verify all periods return expected results

Closes HG-1633