### PR TITLE
fix: prevent double-counting in total_erc1155_accounts (HG-3068)

### DIFF
--- a/src/metrics/evm/total_erc1155_accounts.sql
+++ b/src/metrics/evm/total_erc1155_accounts.sql
@@ -55,9 +55,9 @@ base_holders AS (
 -- Aggregate new holders by the period of their first receipt within the window
 new_holders_per_period AS (
     SELECT
-        DATE_TRUNC(
+        date_trunc(
             period,
-            to_timestamp(first_receipt_timestamp / 1000000000.0)
+            first_receipt_timestamp::timestamp9::timestamp
         ) as period_start_timestamp,
         COUNT(*) as new_holders
     FROM first_receipt_per_holder
@@ -69,8 +69,8 @@ new_holders_per_period AS (
 -- Calculate rolling total: base + cumulative new holders
 SELECT
     int8range(
-        EXTRACT(EPOCH FROM period_start_timestamp)::bigint * 1000000000,
-        EXTRACT(EPOCH FROM LEAD(period_start_timestamp) OVER (ORDER BY period_start_timestamp))::bigint * 1000000000
+        period_start_timestamp::timestamp9::bigint,
+        (LEAD(period_start_timestamp) OVER (ORDER BY period_start_timestamp))::timestamp9::bigint
     ) as int8range,
     (SELECT base FROM base_holders) +
         SUM(new_holders) OVER (ORDER BY period_start_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as total

--- a/src/metrics/evm/total_erc1155_accounts.sql
+++ b/src/metrics/evm/total_erc1155_accounts.sql
@@ -10,20 +10,28 @@ RETURNS SETOF ecosystem.metric_total
 LANGUAGE sql STABLE
 AS $$
 
-WITH 
+WITH
 -- ERC-1155 event signatures (TransferSingle and TransferBatch)
 erc1155_signatures AS (
-    SELECT 
+    SELECT
         '\xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'::bytea as transfer_single,
         '\x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb'::bytea as transfer_batch
 ),
 
--- Count holders before the window starts (baseline)
-base_holders AS (
-    SELECT COUNT(DISTINCT holder_address) as base
+-- First receipt timestamp per holder across all history up to end_timestamp.
+-- Computing the global first receipt (not just within the window) is what lets
+-- us split holders into a pre-window baseline vs new-in-window without
+-- double-counting an address that received both before and during the window.
+-- The recipient address is decoded from topic3 of the TransferSingle/Batch
+-- events; the zero address is excluded as it represents mints/burns.
+first_receipt_per_holder AS (
+    SELECT
+        holder_address,
+        MIN(consensus_timestamp) as first_receipt_timestamp
     FROM (
-        SELECT DISTINCT 
-            CASE 
+        SELECT
+            consensus_timestamp,
+            CASE
                 WHEN length(topic3) = 20 THEN '0x' || encode(topic3, 'hex')
                 WHEN length(topic3) < 20 THEN '0x' || lpad(encode(topic3, 'hex'), 40, '0')
                 ELSE '0x' || encode(substring(topic3 from length(topic3)-19 for 20), 'hex')
@@ -31,56 +39,40 @@ base_holders AS (
         FROM contract_log
         CROSS JOIN erc1155_signatures
         WHERE topic0 IN (transfer_single, transfer_batch)
-          AND consensus_timestamp < start_timestamp
-    ) pre_window
-    WHERE holder_address != '0x0000000000000000000000000000000000000000'
-),
-
--- Get all receipt events within the time window
-receipt_events AS (
-    SELECT 
-        consensus_timestamp,
-        CASE 
-            WHEN length(topic3) = 20 THEN '0x' || encode(topic3, 'hex')
-            WHEN length(topic3) < 20 THEN '0x' || lpad(encode(topic3, 'hex'), 40, '0')
-            ELSE '0x' || encode(substring(topic3 from length(topic3)-19 for 20), 'hex')
-        END as holder_address
-    FROM contract_log
-    CROSS JOIN erc1155_signatures
-    WHERE topic0 IN (transfer_single, transfer_batch)
-      AND consensus_timestamp BETWEEN start_timestamp AND end_timestamp
-),
-
--- Identify first receipt timestamp for each address (excluding zero address)
-first_receipt_per_holder AS (
-    SELECT 
-        holder_address,
-        MIN(consensus_timestamp) as first_receipt_timestamp
-    FROM receipt_events
+          AND consensus_timestamp <= end_timestamp
+    ) decoded
     WHERE holder_address != '0x0000000000000000000000000000000000000000'
     GROUP BY holder_address
 ),
 
--- Aggregate new holders by period
+-- Count holders whose first receipt predates the window (baseline)
+base_holders AS (
+    SELECT COUNT(*) as base
+    FROM first_receipt_per_holder
+    WHERE first_receipt_timestamp < start_timestamp
+),
+
+-- Aggregate new holders by the period of their first receipt within the window
 new_holders_per_period AS (
-    SELECT 
+    SELECT
         DATE_TRUNC(
-            period, 
+            period,
             to_timestamp(first_receipt_timestamp / 1000000000.0)
         ) as period_start_timestamp,
-        COUNT(DISTINCT holder_address) as new_holders
+        COUNT(*) as new_holders
     FROM first_receipt_per_holder
+    WHERE first_receipt_timestamp BETWEEN start_timestamp AND end_timestamp
     GROUP BY period_start_timestamp
     ORDER BY period_start_timestamp
 )
 
 -- Calculate rolling total: base + cumulative new holders
-SELECT 
+SELECT
     int8range(
         EXTRACT(EPOCH FROM period_start_timestamp)::bigint * 1000000000,
         EXTRACT(EPOCH FROM LEAD(period_start_timestamp) OVER (ORDER BY period_start_timestamp))::bigint * 1000000000
     ) as int8range,
-    (SELECT base FROM base_holders) + 
+    (SELECT base FROM base_holders) +
         SUM(new_holders) OVER (ORDER BY period_start_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as total
 FROM new_holders_per_period
 ORDER BY period_start_timestamp;


### PR DESCRIPTION
## Summary

Fixes a counting bug in the existing `total_erc1155_accounts` metric. On incremental loader runs it could count some holders twice, slightly inflating the total. Same bug (and same fix) as the one found in `total_erc20_accounts` during the HG-2957 review.

## What Changed

- Reworked the function to compute each holder's **global** first receipt once, then split that single set into "before the window" (baseline) vs "first seen inside the window" (new per period). Each address is now counted exactly once.
- No change to the metric's meaning, output shape, or the loader wiring - purely a correctness fix.

## Why

The old version counted "holders before the window" separately from "new holders inside the window", but derived the second group from a window-only first-receipt. An address that received an ERC-1155 token before the window and again inside it landed in both groups. Since every scheduled run after the first backfill uses a non-zero start, the inflation crept in and compounded.

## Testing

Verified on mainnet (via Hgraph) with a mid-history start (2026-01-01):

| | base | new | total |
|---|---|---|---|
| True distinct holders | - | - | **643** |
| Fixed | 629 | 14 | **643** ✓ |
| Old (buggy) | 629 | 15 | **644** ✗ |

How to test on the stats DB (testnet first, then mainnet):
1. `SELECT * FROM ecosystem.total_erc1155_accounts('month', 0, current_timestamp::timestamp9::bigint);` - tail equals the true distinct holder count.
2. Run with a non-zero start (e.g. a recent period boundary) and confirm the tail still equals the full distinct count, not higher.
3. `CALL ecosystem.load_metrics_day();` twice - totals for past periods do not increase on the second run.

Edge cases covered:
- Returning holders (received before and during the window) counted once.
- Zero address excluded (mints/burns), same as before.

## Notes / Risks

- Low urgency (ERC-1155 volumes are tiny today, so the live error is small), but it's a real correctness bug.
- Draft until a stats-DB smoke test is run.

Linear: HG-3068